### PR TITLE
Add validation server and update link regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ npm test
 ```
 
 The tests cover the helper functions used for link validation and prompt generation.
+
+## Running the Server
+
+After installing dependencies you can start a simple validation server with:
+
+```bash
+npm start
+```
+
+It will listen on the port specified by the `PORT` environment variable or `3000` by default. Send a request to `/validate?url=YOUR_LINK` to validate an hh.ru vacancy link.

--- a/helpers.js
+++ b/helpers.js
@@ -2,7 +2,7 @@ function validateHhLink(text='') {
   if (typeof text !== 'string') {
     return { isValid: false };
   }
-  const regex = /^https?:\/\/(?:[\w-]+\.)?hh\.ru\/vacancy\/(\d+)(?:\S*)?/i;
+  const regex = /^(?:https?:\/\/)?(?:[\w-]+\.)?hh\.ru\/vacancy\/(\d+)(?:\/?[^\s]*)?$/i;
   const match = text.trim().match(regex);
   if (match) {
     return { isValid: true, vacancyId: match[1], url: match[0] };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,21 @@
+const http = require('http');
+const { validateHhLink } = require('./helpers');
+
+const PORT = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url.startsWith('/validate')) {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const link = url.searchParams.get('url') || '';
+    const result = validateHhLink(link);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify(result));
+  } else {
+    res.statusCode = 404;
+    res.end('Not Found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "commonjs",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "start": "node index.js"
   },
   "devDependencies": {
     "jest": "^29.7.0"

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -3,6 +3,8 @@ const { validateHhLink, createPrompt } = require('../helpers');
 test('validateHhLink accepts various hh.ru URLs', () => {
   expect(validateHhLink('https://hh.ru/vacancy/123').isValid).toBe(true);
   expect(validateHhLink('http://m.hh.ru/vacancy/456?query=1').vacancyId).toBe('456');
+  expect(validateHhLink('hh.ru/vacancy/789').isValid).toBe(true);
+  expect(validateHhLink('https://spb.hh.ru/vacancy/123/').vacancyId).toBe('123');
   expect(validateHhLink('invalid').isValid).toBe(false);
 });
 


### PR DESCRIPTION
## Summary
- improve `validateHhLink` to handle links without protocol and with extra path
- add small HTTP server (`index.js`) for running on basic Node hosting
- expose `npm start` script and document server usage
- extend link validation tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c1da8781c832bac3d374d88bb7f69